### PR TITLE
Add CDE loss to metrics

### DIFF
--- a/metric_scripts/pz_stats_2Gauss_and_BPZ.ipynb
+++ b/metric_scripts/pz_stats_2Gauss_and_BPZ.ipynb
@@ -291,6 +291,30 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Next we can calculate the CDE loss described in Izbicki & Lee 2017 (arXiv:1704.08095)\n",
+    "\n",
+    "$$ \\int \\int ((p(z \\mid x) - \\hat{p}(z \\mid x))^{2} dz dP(x) $$\n",
+    "\n",
+    "which extends L2 density estimation loss to conditional density estimation.  We can estimate this quantity (up to an unknown additive constant which depends on the true conditional densities) from data as\n",
+    "\n",
+    "$$ \\frac{1}{n} \\sum_{i=1}^{n} \\int \\hat{p}^{2}(z \\mid x_{i}) dz - \\frac{2}{n} \\sum_{i=1}^{n} \\hat{p}(z_{i} \\mid x_{i}) $$\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cde_loss = testme.cde_loss(np.linspace(0.5, 10.0, 1000))\n",
+    "print cde_loss"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "We can make a QQ plot as well."
    ]
   },


### PR DESCRIPTION
Adds the calculation of the conditional density loss described in Izbicki, Lee & Freeman 2016 ([arXiv:1604.01339](https://arxiv.org/abs/1604.01339)).  There is a way one can directly compare the performance of individual p(z) estimates, that is, estimates of conditional densities f(z|x) where x represents photometric covariates, and this metric (which is the CDE equivalent of RMSE in regression) can be estimated from validation data without knowing the true density; see Equations 4 and 5 in the[ arXiv paper].
